### PR TITLE
Phone Number Validation Fix

### DIFF
--- a/src/components/forms/DetailsForm/DetailsForm.tsx
+++ b/src/components/forms/DetailsForm/DetailsForm.tsx
@@ -26,7 +26,14 @@ export function DetailsForm({
     saveSuccess,
     onSubmit: handleSubmit,
   } = useDetailsForm({
-    onSubmit,
+    onSubmit: async (data) => {
+      // If phone is just a country code, treat as undefined
+      let phone = data.phone;
+      if (phone && /^\+\d{1,4}$/.test(phone.trim())) {
+        phone = undefined;
+      }
+      await onSubmit({ ...data, phone });
+    },
     user,
     initialData,
   });

--- a/src/components/forms/DetailsForm/schema.ts
+++ b/src/components/forms/DetailsForm/schema.ts
@@ -28,7 +28,11 @@ export const detailsFormSchema = z.object({
       if (!phone || phone.trim() === '') {
         return true;
       }
-      
+      // If phone is just a country code (e.g., '+1', '+44'), treat as empty
+      const onlyCountryCode = /^\+\d{1,4}$/.test(phone.trim());
+      if (onlyCountryCode) {
+        return true;
+      }
       // Validate using google-libphonenumber as recommended by react-international-phone
       return isPhoneValid(phone);
     }, {

--- a/src/components/forms/HeaderForm/HeaderForm.tsx
+++ b/src/components/forms/HeaderForm/HeaderForm.tsx
@@ -11,6 +11,7 @@ import { useHeaderForm } from './useHeaderForm';
 import { HeaderFormValues } from './schema';
 import { Typography } from '@/components/ui/typography';
 import { forwardRef, useEffect } from 'react';
+import { UseFormReturn } from 'react-hook-form';
 
 export type HeaderFormProps = {
   onSubmitSuccess: (data: HeaderFormValues) => Promise<void> | void;
@@ -35,10 +36,23 @@ export const HeaderForm = forwardRef<HTMLFormElement, HeaderFormProps>(
       form,
       isPending,
       onSubmit: handleFormSubmit,
+    }: {
+      form: UseFormReturn<HeaderFormValues>;
+      isPending: boolean;
+      onSubmit: (data: HeaderFormValues) => Promise<void>;
     } = useHeaderForm({
       onSubmit: onSubmitSuccess,
       defaultValues,
     });
+
+    // Wrapper to normalize phoneNumber before calling onSubmitSuccess
+    const handlePhoneNumberSubmit = async (data: HeaderFormValues) => {
+      let phoneNumber = data.phoneNumber;
+      if (phoneNumber && /^\+\d{1,4}$/.test(phoneNumber.trim())) {
+        phoneNumber = undefined;
+      }
+      await handleFormSubmit({ ...data, phoneNumber });
+    };
 
     // Notify parent of pending state changes
     useEffect(() => {
@@ -51,7 +65,7 @@ export const HeaderForm = forwardRef<HTMLFormElement, HeaderFormProps>(
       <Form {...form}>
         <form
           ref={ref}
-          onSubmit={form.handleSubmit(handleFormSubmit)}
+          onSubmit={form.handleSubmit(handlePhoneNumberSubmit)}
           noValidate
           className="space-y-5"
         >

--- a/src/components/forms/HeaderForm/schema.ts
+++ b/src/components/forms/HeaderForm/schema.ts
@@ -41,7 +41,11 @@ export const headerSchema = z.object({
       if (!phone || phone.trim() === '') {
         return true;
       }
-      
+      // If phone is just a country code (e.g., '+1', '+44'), treat as empty
+      const onlyCountryCode = /^\+\d{1,4}$/.test(phone.trim());
+      if (onlyCountryCode) {
+        return true;
+      }
       // Validate using google-libphonenumber
       return isPhoneValid(phone);
     }, {


### PR DESCRIPTION
As the phone number input was defaulting to using the country code when the phone number was empty, this was being treated as an invalid phone number. This has been resolved by adding logic to handle this scenario and treat a 'country code only' number as empty, allowing form submission.