### PR TITLE
Fixed New Conversation Display

### DIFF
--- a/src/app/dashboard/messages/page.tsx
+++ b/src/app/dashboard/messages/page.tsx
@@ -3,6 +3,8 @@ import { DashboardMessagesPage } from '@/components/pages/DashboardMessagesPage/
 // Enable caching for 1 minute
 export const revalidate = 60;
 
-export default function MessagesPage() {
-  return <DashboardMessagesPage />;
+// Accept searchParams as a Promise and await it before passing to DashboardMessagesPage
+export default async function MessagesPage({ searchParams }: { searchParams: Promise<{ conversation?: string }> }) {
+  const resolvedSearchParams = await searchParams;
+  return <DashboardMessagesPage searchParams={resolvedSearchParams} />;
 }

--- a/src/components/pages/DashboardMessagesPage/DashboardMessagesPage.tsx
+++ b/src/components/pages/DashboardMessagesPage/DashboardMessagesPage.tsx
@@ -5,7 +5,7 @@ import { redirect } from 'next/navigation';
 import { DashboardMessagesPageClient } from './DashboardMessagesPageClient';
 import { getConversations, getAvailableProfessionals } from '@/server/domains/messages/actions';
 
-export async function DashboardMessagesPage() {
+export async function DashboardMessagesPage({ searchParams }: { searchParams: { conversation?: string } }) {
   const supabase = await createClient();
 
   // Get the current user
@@ -22,8 +22,11 @@ export async function DashboardMessagesPage() {
     user_uuid: user.id,
   });
 
-  // Fetch conversations
-  const conversationsResult = await getConversations();
+  // Extract conversationId from searchParams
+  const conversationId = searchParams?.conversation;
+
+  // Fetch conversations, passing conversationId if present
+  const conversationsResult = await getConversations(conversationId);
   const conversations = conversationsResult.success ? conversationsResult.conversations || [] : [];
 
   // For clients, also fetch available professionals
@@ -38,9 +41,9 @@ export async function DashboardMessagesPage() {
   if (!isProfessional) {
     const professionalsResult = await getAvailableProfessionals();
     availableProfessionals = professionalsResult.success ? professionalsResult.professionals || [] : [];
-      }
+  }
 
-    return (
+  return (
     <DashboardMessagesPageClient 
       isProfessional={!!isProfessional}
       initialConversations={conversations}

--- a/src/components/pages/DashboardMessagesPage/DashboardMessagesPageClient.tsx
+++ b/src/components/pages/DashboardMessagesPage/DashboardMessagesPageClient.tsx
@@ -222,7 +222,9 @@ export function DashboardMessagesPageClient({
         const { getConversations } = await import(
           '@/server/domains/messages/actions'
         );
-        const result = await getConversations();
+        // Get conversationId from URL
+        const conversationId = searchParams.get('conversation') || undefined;
+        const result = await getConversations(conversationId);
         if (result.success && result.conversations) {
           setConversations(result.conversations);
         }
@@ -247,7 +249,7 @@ export function DashboardMessagesPageClient({
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       clearInterval(conversationInterval);
     };
-  }, []);
+  }, [searchParams]);
 
   // Enhanced polling for messages with user interaction awareness
   useEffect(() => {

--- a/src/server/domains/messages/actions.ts
+++ b/src/server/domains/messages/actions.ts
@@ -118,94 +118,11 @@ export async function getConversations(conversationId?: string): Promise<{
       })
     );
 
-    // Filter out null values and conversations without messages
-    let validConversations = conversationsWithUsers.filter((conv): conv is NonNullable<typeof conv> => 
-      conv !== null && conv.last_message !== undefined
+    // Filter out null values, and keep conversations that have messages OR match the provided conversationId.
+    const validConversations = conversationsWithUsers.filter((conv): conv is NonNullable<typeof conv> => 
+      conv !== null && (conv.last_message !== undefined || conv.id === conversationId)
     );
 
-    // If a conversationId is provided, ensure it is included
-    if (conversationId && !validConversations.some(conv => conv.id === conversationId)) {
-      // Fetch the conversation directly
-      const { data: conversation, error: conversationError } = await supabase
-        .from('conversations')
-        .select('*')
-        .eq('id', conversationId)
-        .or(`client_id.eq.${user.id},professional_id.eq.${user.id}`)
-        .single();
-
-      if (conversation && !conversationError) {
-        // Get the other user's details
-        const otherUserId = isProfessional ? conversation.client_id : conversation.professional_id;
-        const { data: otherUser } = await supabase
-          .from('users')
-          .select(`
-            id,
-            first_name,
-            last_name,
-            profile_photos (url)
-          `)
-          .eq('id', otherUserId)
-          .single();
-
-        // Get last message
-        const { data: lastMessageData } = await supabase
-          .from('messages')
-          .select(`
-            *,
-            attachments:message_attachments(*)
-          `)
-          .eq('conversation_id', conversation.id)
-          .order('created_at', { ascending: false })
-          .limit(1)
-          .single();
-
-        const lastMessage = lastMessageData ? {
-          id: lastMessageData.id,
-          conversation_id: lastMessageData.conversation_id,
-          sender_id: lastMessageData.sender_id,
-          content: lastMessageData.content,
-          is_read: lastMessageData.is_read,
-          created_at: lastMessageData.created_at,
-          updated_at: lastMessageData.updated_at,
-          attachments: lastMessageData.attachments?.map(att => ({
-            id: att.id,
-            message_id: att.message_id,
-            url: att.url,
-            type: 'image' as const,
-            file_name: att.file_name,
-            file_size: att.file_size,
-            created_at: att.created_at
-          })) || []
-        } : undefined;
-
-        // Count unread messages for the current user
-        const { count: unreadCount } = await supabase
-          .from('messages')
-          .select('*', { count: 'exact', head: true })
-          .eq('conversation_id', conversation.id)
-          .neq('sender_id', user.id)
-          .eq('is_read', false);
-
-        // Only add if not already present
-        validConversations = [
-          ...validConversations,
-          {
-            ...conversation,
-            other_user: {
-              id: otherUser?.id || '',
-              first_name: otherUser?.first_name || '',
-              last_name: otherUser?.last_name || '',
-              profile_photo_url: Array.isArray(otherUser?.profile_photos) 
-                ? otherUser.profile_photos[0]?.url 
-                : otherUser?.profile_photos?.url || undefined,
-            },
-            last_message: lastMessage,
-            unread_count: unreadCount || 0,
-          }
-        ];
-      }
-    }
-    
     return { success: true, conversations: validConversations };
   } catch (error) {
     console.error('Error in getConversations:', error);


### PR DESCRIPTION
When clicking 'Message' from a Professional Page and being redirected to the Dashboard Messages page, the subsequently created or fetched conversation was being filtered out from the results as it contained no messages.

The conversation from the URL parameter is now passed to the backend function so that this conversation can be included in the final list of conversations for the user in the UI. This ensures that a user can immediately begin typing a new message.

(Note that this is only in the case where the conversation URL parameter is present. If not, the conversation between the two users will be filtered out as normal.)