### PR TITLE
Added Post Verification Redirect URL Passthrough

### DIFF
--- a/src/api/auth/actions.ts
+++ b/src/api/auth/actions.ts
@@ -25,7 +25,7 @@ const getURL = () => {
 /**
  * Server action for user signup
  */
-export async function signUpAction(data: SignUpFormValues) {
+export async function signUpAction(data: SignUpFormValues, redirectTo?: string) {
   const supabase = await createClient();
   
   try {
@@ -44,7 +44,7 @@ export async function signUpAction(data: SignUpFormValues) {
           last_name: data.lastName,
           role: data.userType,
         },
-        emailRedirectTo: `${getURL()}/auth/callback`,
+        emailRedirectTo: `${getURL()}/auth/callback?redirect_to=${encodeURIComponent(redirectTo || '/profile')}`,
       },
     });
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -162,7 +162,7 @@ export async function GET(request: Request) {
         
         // Add a small delay to ensure all database operations are complete
         await new Promise(resolve => setTimeout(resolve, 1000));
-        
+
         console.log('Redirecting to:', redirectTo);
         
         // Create response and set session cookie explicitly

--- a/src/components/forms/SignUpForm/SignUpForm.tsx
+++ b/src/components/forms/SignUpForm/SignUpForm.tsx
@@ -26,6 +26,7 @@ export function SignUpForm({
   } = useSignUpForm({
     onSubmit,
     redirectToDashboard,
+    redirectTo
   });
 
   return (

--- a/src/components/forms/SignUpForm/useSignUpForm.ts
+++ b/src/components/forms/SignUpForm/useSignUpForm.ts
@@ -12,12 +12,14 @@ export type UseSignUpFormProps = {
   onSubmit: (data: SignUpFormValues) => void;
   defaultValues?: Partial<SignUpFormValues>;
   redirectToDashboard?: boolean;
+  redirectTo?: string;
 };
 
 export function useSignUpForm({ 
   onSubmit, 
   defaultValues,
-  redirectToDashboard = false
+  redirectToDashboard = false,
+  redirectTo = '/profile',
 }: UseSignUpFormProps) {
   const [isPending, setIsPending] = useState(false);
   const router = useRouter();
@@ -37,8 +39,9 @@ export function useSignUpForm({
     try {
       setIsPending(true);
       
-      // Call the server action for signup
-      const result = await signUpAction(data);
+      console.log('redirectTo', redirectTo);
+      // Call the server action for signup with redirectTo
+      const result = await signUpAction(data, redirectTo);
       
       if (!result.success) {
         toast({
@@ -73,7 +76,7 @@ export function useSignUpForm({
     } finally {
       setIsPending(false);
     }
-  }, [onSubmit, router, redirectToDashboard]);
+  }, [onSubmit, router, redirectToDashboard, redirectTo]);
 
   return {
     form,

--- a/src/components/modals/SignUpModal/SignUpModal.tsx
+++ b/src/components/modals/SignUpModal/SignUpModal.tsx
@@ -11,6 +11,7 @@ type SignUpModalProps = {
   onSignInClick?: () => void;
   onSuccess?: () => void;
   redirectToDashboard?: boolean;
+  redirectTo?: string;
 };
 
 export function SignUpModal({
@@ -19,6 +20,7 @@ export function SignUpModal({
   onSignInClick,
   onSuccess,
   redirectToDashboard = false,
+  redirectTo = '/profile',
 }: SignUpModalProps) {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const router = useRouter();
@@ -53,8 +55,6 @@ export function SignUpModal({
       onSignInClick();
     }
   };
-
-  const redirectTo = redirectToDashboard ? '/profile' : '/profile';
 
   return (
     <Modal

--- a/src/components/templates/ServicesTemplate/components/ServicesTemplateListSection/components/ServicesTemplateServiceCard/ServicesTemplateServiceCard.tsx
+++ b/src/components/templates/ServicesTemplate/components/ServicesTemplateListSection/components/ServicesTemplateServiceCard/ServicesTemplateServiceCard.tsx
@@ -67,8 +67,11 @@ export function ServicesTemplateServiceCard({
   const handleAuthSuccess = () => {
     setIsSignInModalOpen(false);
     setIsSignUpModalOpen(false);
-    // After successful authentication, redirect to booking page
-    router.push(`/booking/${service.id}`);
+    
+    // After successful authentication, redirect to booking page only if logged in
+    if (isAuthenticated) {
+      router.push(`/booking/${service.id}`);
+    }
   };
 
   const getInitials = (name: string) => {
@@ -295,6 +298,7 @@ export function ServicesTemplateServiceCard({
         onOpenChange={setIsSignUpModalOpen}
         onSignInClick={handleSignInClick}
         onSuccess={handleAuthSuccess}
+        redirectTo={`/booking/${service.id}`}
       />
     </>
   );


### PR DESCRIPTION
A redirectTo Prop has been added to the SignUpModal and propagated through the Sign Up and Email Verification Flow so that the user is redirected to the specified page after clicking the verification link in the email.

When clicking the Book Now button, the intended booking page URL is passed so that the user can continue booking seamlessly.

Also tidied up the Submit handler so that a redirect is only performed to the booking page if the user has successfully logged in.