### PR TITLE
Fixed Non-Subscribed Professional Services Booking

### DIFF
--- a/src/components/pages/ProfileServicesPage/ProfileServicesPage.tsx
+++ b/src/components/pages/ProfileServicesPage/ProfileServicesPage.tsx
@@ -75,6 +75,17 @@ export async function ProfileServicesPage({
     redirect('/');
   }
 
+  // Fetch isBookable (professional is subscribed)
+  let isBookable = false;
+  const { data: profileData } = await supabase
+    .from('professional_profiles')
+    .select('is_subscribed')
+    .eq('user_id', targetUserId)
+    .single();
+  if (profileData && profileData.is_subscribed === true) {
+    isBookable = true;
+  }
+
   // Extract search parameters
   const resolvedSearchParams = searchParams ? await searchParams : {};
   const page =
@@ -112,6 +123,7 @@ export async function ProfileServicesPage({
       initialSearch={search}
       isEditable={isEditable}
       serviceLimitInfo={serviceLimitInfo}
+      isBookable={isBookable}
     />
   );
 }

--- a/src/components/pages/ProfileServicesPage/ProfileServicesPageClient.tsx
+++ b/src/components/pages/ProfileServicesPage/ProfileServicesPageClient.tsx
@@ -35,6 +35,7 @@ export type ProfileServicesPageClientProps = {
   initialSearch: string;
   isEditable?: boolean;
   serviceLimitInfo?: ServiceLimitInfo | null;
+  isBookable?: boolean;
 };
 
 // ServiceCard component
@@ -50,6 +51,7 @@ function ServiceCard({
   isAtLimit = false,
   authStatus,
   onBookNowClick,
+  isBookable = false,
 }: {
   service: ServiceUI;
   onEdit: (service: ServiceUI) => void;
@@ -66,10 +68,12 @@ function ServiceCard({
     isClient: boolean;
   };
   onBookNowClick?: (serviceId: string) => void;
+  isBookable?: boolean;
 }) {
   // Determine if the Book Now button should be shown
   const shouldShowBookButton =
     !isEditable &&
+    isBookable &&
     authStatus &&
     (!authStatus.isAuthenticated || authStatus.isClient);
 
@@ -296,6 +300,7 @@ export function ProfileServicesPageClient({
   initialServices,
   isEditable = true,
   serviceLimitInfo,
+  isBookable = false,
 }: ProfileServicesPageClientProps) {
   // State
   const [services, setServices] = useState<ServiceUI[]>(initialServices);
@@ -659,6 +664,7 @@ export function ProfileServicesPageClient({
                 isAtLimit={isAtLimit}
                 authStatus={authStatus}
                 onBookNowClick={handleBookNowClick}
+                isBookable={isBookable}
               />
             ))}
           </div>
@@ -707,6 +713,7 @@ export function ProfileServicesPageClient({
                     isAtLimit={isAtLimit}
                     authStatus={authStatus}
                     onBookNowClick={handleBookNowClick}
+                    isBookable={isBookable}
                   />
                 ))}
               </>

--- a/src/components/templates/BookingPageTemplate/actions.ts
+++ b/src/components/templates/BookingPageTemplate/actions.ts
@@ -91,6 +91,11 @@ export async function getServiceForBooking(serviceId: string): Promise<ServiceLi
       return null;
     }
 
+    // Check if professional profile is subscribed
+    if (!professionalProfile?.is_subscribed) {
+      return null;
+    }
+
     // Handle profile_photo structure safely - it might not exist
     let profilePhotoUrl: string | undefined = undefined;
     if (user?.profile_photo) {


### PR DESCRIPTION
Added fetching of the professional's profile for the Profile Services Page to check if the professional is subscribed, and used this Boolean as part of the condition for showing the Book Now button.

Also added null return when fetching the service for a booking page when the professional is not subscribed, which should trigger the redirect to notFound.