### PR TITLE
Updated Closest Location Sorting

### DIFF
--- a/src/api/profiles/queriesProfessional.ts
+++ b/src/api/profiles/queriesProfessional.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { createClient } from '@/lib/supabase/client';
+import { Address } from './types';
+
+async function getProfessionalProfileWithAddress(userId: string): Promise<{ address: Address | null }> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('professional_profiles')
+    .select('address_id')
+    .eq('user_id', userId)
+    .single();
+  if (error || !data?.address_id) return { address: null };
+  const { data: address, error: addrError } = await supabase
+    .from('addresses')
+    .select('*')
+    .eq('id', data.address_id)
+    .single();
+  if (addrError) return { address: null };
+  return { address };
+}
+
+export function useProfessionalProfileWithAddress(userId: string | undefined) {
+  return useQuery({
+    queryKey: ['professionalProfileWithAddress', userId],
+    queryFn: () => (userId ? getProfessionalProfileWithAddress(userId) : Promise.resolve({ address: null })),
+    enabled: !!userId,
+  });
+}

--- a/src/components/templates/ServicesTemplate/components/ClientServicesContainer/ClientServicesContainer.tsx
+++ b/src/components/templates/ServicesTemplate/components/ClientServicesContainer/ClientServicesContainer.tsx
@@ -18,6 +18,7 @@ import {
   useServicesState,
   useURLSync,
 } from './hooks';
+import { useUserDefaultLocation } from './useUserDefaultLocation';
 import { useSearch } from '@/stores/searchStore';
 
 type ClientServicesContainerProps = {
@@ -183,6 +184,7 @@ export function ClientServicesContainer({
   initialSortBy = 'name-asc',
   authStatus,
 }: ClientServicesContainerProps) {
+  const userDefaultLocation = useUserDefaultLocation();
   const containerRef = useRef<HTMLDivElement>(null);
   const [isLoadingServices, setIsLoadingServices] = useState(false);
   const { resetSearch } = useSearch();
@@ -202,6 +204,7 @@ export function ClientServicesContainer({
     initialSearchTerm,
     initialLocation,
     initialSortBy,
+    userDefaultLocation
   );
 
   // Set up server-side search without page reload

--- a/src/components/templates/ServicesTemplate/components/ClientServicesContainer/hooks.ts
+++ b/src/components/templates/ServicesTemplate/components/ClientServicesContainer/hooks.ts
@@ -56,6 +56,7 @@ export function useServicesState(
   initialSearchTerm: string,
   initialLocation: string = '',
   initialSortBy: SortOption = 'name-asc',
+  userDefaultLocation?: { latitude: number; longitude: number } | null
 ) {
   const [services, setServices] = useState<ServiceListItem[]>(initialServices);
   const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
@@ -70,21 +71,27 @@ export function useServicesState(
   const filteredServices = useMemo(
     () => {
       const filtered = filterServices(services, filters);
-      return sortServices(filtered, filters.sortBy);
+      // Pass userDefaultLocation only if location filter is empty
+      const locationArg = !filters.location ? userDefaultLocation : undefined;
+      return sortServices(filtered, filters.sortBy, locationArg);
     },
-    [services, filters],
+    [services, filters, userDefaultLocation],
   );
 
   // Get services to display
   const displayedServices = useMemo(
-    () => getServicesForDisplay(
-      initialServices,
-      filteredServices,
-      filters,
-      pagination.currentPage,
-      pagination.pageSize
-    ),
-    [initialServices, filteredServices, filters, pagination]
+    () => {
+      const locationArg = !filters.location ? userDefaultLocation : undefined;
+      return getServicesForDisplay(
+        initialServices,
+        filteredServices,
+        filters,
+        pagination.currentPage,
+        pagination.pageSize,
+        locationArg
+      );
+    },
+    [initialServices, filteredServices, filters, pagination, userDefaultLocation]
   );
 
   return {

--- a/src/components/templates/ServicesTemplate/components/ClientServicesContainer/useUserDefaultLocation.ts
+++ b/src/components/templates/ServicesTemplate/components/ClientServicesContainer/useUserDefaultLocation.ts
@@ -1,0 +1,106 @@
+
+
+import { useEffect, useState } from 'react';
+import { useAuthStore } from '@/stores/authStore';
+import { useQuery } from '@tanstack/react-query';
+import { getClientProfileWithAddress } from '@/api/profiles/fetchers';
+import { useProfessionalProfileWithAddress } from '@/api/profiles/queriesProfessional';
+
+
+
+// Custom hook for browser geolocation
+export function useBrowserGeolocation() {
+  const [geoLocation, setGeoLocation] = useState<{ latitude: number; longitude: number } | null>(null);
+  const [geoTried, setGeoTried] = useState(false);
+  useEffect(() => {
+    if (!geoLocation && !geoTried) {
+      if (typeof window !== 'undefined' && 'geolocation' in navigator) {
+        navigator.geolocation.getCurrentPosition(
+          (pos) => {
+            setGeoLocation({
+              latitude: pos.coords.latitude,
+              longitude: pos.coords.longitude,
+            });
+            setGeoTried(true);
+          },
+          () => setGeoTried(true),
+          { enableHighAccuracy: false, timeout: 5000 }
+        );
+      } else {
+        setGeoTried(true);
+      }
+    }
+  }, [geoLocation, geoTried]);
+
+  return geoLocation;
+}
+
+
+
+export function useUserDefaultLocation() {
+  // Get the current user from auth store's getUser method
+  const getUser = useAuthStore((state) => state.getUser);
+  const userId = getUser()?.id;
+
+  // Always call the browser geolocation hook
+  const geoLocation = useBrowserGeolocation();
+
+  // Always call the queries, but only enable if userId exists
+  const { data, isLoading } = useQuery({
+    queryKey: ['clientProfileWithAddress', userId],
+    queryFn: async () => {
+      if (!userId) return { address: null };
+      try {
+        return await getClientProfileWithAddress(userId);
+      } catch (err: unknown) {
+        // Suppress 406 (Not Acceptable) and PGRST116 errors
+        if (
+          typeof err === 'object' && err !== null &&
+          ((
+            'code' in err && (err as { code?: string }).code === 'PGRST116' &&
+            'message' in err && typeof (err as { message?: string }).message === 'string' &&
+            (err as { message?: string }).message?.includes('no rows returned')
+          ) || (
+            'status' in err && (err as { status?: number }).status === 406
+          ))
+        ) {
+          return { address: null };
+        }
+        throw err;
+      }
+    },
+    enabled: !!userId,
+  });
+
+  // Use the professional profile hook directly
+  const { data: profData, isLoading: isProfLoading } = useProfessionalProfileWithAddress(userId);
+
+  // Try to get latitude/longitude from client profile address
+  const address = data?.address;
+  if (
+    address &&
+    typeof address.latitude === 'number' &&
+    typeof address.longitude === 'number' &&
+    !isLoading
+  ) {
+    return { latitude: address.latitude, longitude: address.longitude };
+  }
+
+  // Fallback: Try professional profile address
+  const profAddress = profData?.address;
+  if (
+    profAddress &&
+    typeof profAddress.latitude === 'number' &&
+    typeof profAddress.longitude === 'number' &&
+    !isProfLoading
+  ) {
+    return { latitude: profAddress.latitude, longitude: profAddress.longitude };
+  }
+
+  // Final fallback: use browser geolocation
+  if (geoLocation) {
+    return geoLocation;
+  }
+
+  return null;
+}

--- a/src/components/templates/ServicesTemplate/utils.ts
+++ b/src/components/templates/ServicesTemplate/utils.ts
@@ -32,43 +32,77 @@ export function filterServices(
 /**
  * Sorts services based on the selected sort option
  */
+
+/**
+ * Sorts services based on the selected sort option, including distance-based sorting for location-asc.
+ * @param services List of services
+ * @param sortBy Sort option
+ * @param userLocation Optional user location { latitude, longitude }
+ */
 export function sortServices(
   services: ServiceListItem[],
   sortBy: SortOption,
+  userLocation?: { latitude: number; longitude: number } | null
 ): ServiceListItem[] {
   const sortedServices = [...services];
-  
+
   switch (sortBy) {
     case 'name-asc':
       return sortedServices.sort((a, b) => a.name.localeCompare(b.name));
-    
+
     case 'name-desc':
       return sortedServices.sort((a, b) => b.name.localeCompare(a.name));
-    
+
     case 'location-asc': {
-      // First, sort by city and name as before
-      const citySorted = sortedServices.sort((a, b) => {
-        const locationA = a.professional.address_data?.city || a.professional.address || '';
-        const locationB = b.professional.address_data?.city || b.professional.address || '';
-        const cityComparison = locationA.localeCompare(locationB);
-        if (cityComparison !== 0) {
-          return cityComparison;
+      // If no user location, fallback to alphabetical by city
+      if (!userLocation) {
+        return sortedServices.sort((a, b) => {
+          const locationA = a.professional.address_data?.city || a.professional.address || '';
+          const locationB = b.professional.address_data?.city || b.professional.address || '';
+          const cityComparison = locationA.localeCompare(locationB);
+          if (cityComparison !== 0) {
+            return cityComparison;
+          }
+          return a.name.localeCompare(b.name);
+        });
+      }
+      // Sort by distance to user location
+      return sortedServices.sort((a, b) => {
+        const distA = getDistanceFromUser(userLocation, a.professional.address_data || undefined);
+        const distB = getDistanceFromUser(userLocation, b.professional.address_data || undefined);
+        if (distA === distB) {
+          return a.name.localeCompare(b.name);
         }
-        // If cities are the same, sort by service name
-        return a.name.localeCompare(b.name);
-      });
-      // Then, move all with non-null address_data to the top, preserving order
-      return citySorted.sort((a, b) => {
-        const aHasAddress = !!a.professional.address_data;
-        const bHasAddress = !!b.professional.address_data;
-        if (aHasAddress === bHasAddress) return 0;
-        return aHasAddress ? -1 : 1;
+        return distA - distB;
       });
     }
-    
+
     default:
       return sortedServices;
   }
+}
+
+/**
+ * Calculates the distance (in meters) between the user and a service's address using the Haversine formula.
+ * Returns Infinity if address_data is missing or invalid.
+ */
+function getDistanceFromUser(
+  userLoc: { latitude: number; longitude: number },
+  addressData?: { latitude?: number; longitude?: number }
+): number {
+  if (!addressData?.latitude || !addressData?.longitude) return Infinity;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const R = 6371e3; // meters
+  const φ1 = toRad(userLoc.latitude);
+  const φ2 = toRad(addressData.latitude!);
+  const Δφ = toRad(addressData.latitude! - userLoc.latitude);
+  const Δλ = toRad(addressData.longitude! - userLoc.longitude);
+  const a =
+    Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
+    Math.cos(φ1) * Math.cos(φ2) *
+    Math.sin(Δλ / 2) * Math.sin(Δλ / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
 }
 
 /**
@@ -113,7 +147,8 @@ export function getServicesForDisplay(
   filteredServices: ServiceListItem[],
   filters: ServicesFilters,
   currentPage: number,
-  pageSize: number
+  pageSize: number,
+  userLocation?: { latitude: number; longitude: number } | null
 ): ServiceListItem[] {
   // If location filter is applied, use server results directly
   // Server-side location filtering is more comprehensive and handles complex address matching
@@ -124,7 +159,7 @@ export function getServicesForDisplay(
   // If no filters are applied, use the services as is (already paginated from server)
   if (filters.searchTerm === '') {
     // Always apply the selected sort to the initial results
-    return sortServices(initialServices, filters.sortBy);
+    return sortServices(initialServices, filters.sortBy, userLocation);
   }
 
   // Otherwise, apply pagination on client-side filtered results (search only)


### PR DESCRIPTION
Updated the closest location sorting to use an actual distance calculation between the supplied location and the coordinates of the returned services.

Added default location which fetches the user's saved address from the database, based on their client or professional profile. For logged out users, or users with no address saved, the function defaults to using the user's current location via the Geolocation API.

This is passed to the sorting function to sort the results accurately by closest distance when Closest Location is selected.