### PR TITLE
Refactored & Fixed Timeslot Selection & Highlighting For Bookings

### DIFF
--- a/src/components/templates/BookingModalTemplate/hooks/useAvailableTimeSlots.ts
+++ b/src/components/templates/BookingModalTemplate/hooks/useAvailableTimeSlots.ts
@@ -10,6 +10,7 @@ import { getAvailableTimeSlots } from '../actions';
 export function useAvailableTimeSlots(
   professionalProfileId: string,
   date: string | null,
+  requiredDurationMinutes: number = 30,
   professionalTimezone: string = 'UTC',
   clientTimezone: string = 'UTC',
   enabled = true
@@ -29,7 +30,7 @@ export function useAvailableTimeSlots(
         return [];
       }
 
-      const slots = await getAvailableTimeSlots(professionalProfileId, date, professionalTimezone, clientTimezone);
+  const slots = await getAvailableTimeSlots(professionalProfileId, date, requiredDurationMinutes, professionalTimezone, clientTimezone);
       console.log('Received time slots:', slots);
       return slots;
     },

--- a/src/components/templates/BookingModalTemplate/hooks/useBookingState.ts
+++ b/src/components/templates/BookingModalTemplate/hooks/useBookingState.ts
@@ -20,32 +20,47 @@ export type BookingModalProps = {
   isOpen: boolean;
   service: ServiceListItem;
   onBookingComplete?: (bookingId: string) => void;
+  selectedExtraServiceIds?: string[];
 };
 
 /**
  * Custom hook to manage booking states and data fetching with timezone awareness
  */
 export function useBookingState(props: BookingModalProps) {
+
+  // Destructure props at the top
+
   const { 
     isOpen, 
     service, 
-    onBookingComplete 
+    onBookingComplete,
+    selectedExtraServiceIds = [],
   } = props;
-  
+  const professional = service.professional;
+  const professionalProfileId = professional.profile_id || '';
+
+  // Use React Query to fetch additional services
+  const {
+    data: additionalServices = [],
+    isLoading: isLoadingAdditionalServices
+  } = useAdditionalServices(
+    professionalProfileId,
+    service.id,
+    isOpen
+  );
+
   // State for tracking booking process
   const { toast } = useToast();
   const [bookingCompleted, setBookingCompleted] = useState(false);
   const [bookingDetails, setBookingDetails] = useState<BookingDetailsState>({});
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  
+
   // Get React Query client for cache invalidation
   const queryClient = useQueryClient();
-  
-  // Get professional info for API calls
-  const professional = service.professional;
-  const professionalProfileId = professional.profile_id || '';
-  
+
+
+
   // Get client's timezone
   const clientTimezone = getUserTimezone();
   
@@ -74,6 +89,9 @@ export function useBookingState(props: BookingModalProps) {
     staleTime: 1000 * 60 * 10, // 10 minutes
   });
   
+
+
+
   // Fetch available dates with timezone context
   const { 
     data: availableDays = [],
@@ -91,6 +109,17 @@ export function useBookingState(props: BookingModalProps) {
     selectedDate ? format(selectedDate, 'yyyy-MM-dd') : null
   , [selectedDate]);
 
+  // Calculate total duration in minutes (main service + selected extra services)
+  const selectedExtraServices = useMemo(() => {
+    if (!Array.isArray(selectedExtraServiceIds) || !Array.isArray(additionalServices)) return [];
+    return additionalServices.filter((service) => selectedExtraServiceIds.includes(service.id));
+  }, [selectedExtraServiceIds, additionalServices]);
+
+  const totalDurationMinutes = useMemo(() => {
+    const extraDuration = selectedExtraServices.reduce((sum, s) => sum + (s.duration || 0), 0);
+    return (service.duration || 0) + extraDuration;
+  }, [service.duration, selectedExtraServices]);
+
   // Use the memoized formatted date for the API call with timezone context
   const { 
     data: availableTimeSlots = [], 
@@ -100,6 +129,7 @@ export function useBookingState(props: BookingModalProps) {
   } = useAvailableTimeSlots(
     professionalProfileId,
     formattedDate,
+    totalDurationMinutes,
     professionalTimezone,
     clientTimezone,
     isOpen && Boolean(selectedDate) && !isLoadingTimezone
@@ -139,15 +169,7 @@ export function useBookingState(props: BookingModalProps) {
     isOpen
   );
   
-  // Use React Query to fetch additional services
-  const {
-    data: additionalServices = [],
-    isLoading: isLoadingAdditionalServices
-  } = useAdditionalServices(
-    professionalProfileId,
-    service.id,
-    isOpen
-  );
+
   
   // Reset state when modal closes
   const handleOpenChange = (open: boolean) => {

--- a/src/components/templates/BookingPageTemplate/components/BookingPageClient.tsx
+++ b/src/components/templates/BookingPageTemplate/components/BookingPageClient.tsx
@@ -42,6 +42,7 @@ export function BookingPageClient({
   });
 
   // Use the existing booking state hook with the page context
+  const selectedExtraServiceIds = formData.extraServices?.map((s) => s.id) || [];
   const {
     bookingCompleted,
     bookingDetails,
@@ -65,6 +66,7 @@ export function BookingPageClient({
       // Redirect to success page or show completion state
       console.log('Booking completed:', bookingId);
     },
+    selectedExtraServiceIds,
   });
 
   // Handle preselected date from URL params


### PR DESCRIPTION
Rewrote the timeslot and availability highlighting to be correct to the length of time of the service and not allow overlapping selections with existing appointments. The duration calculations now use a time-based approach instead of the previous timeslots-based approach.

Highlighting should now not highlight non-consecutive timeslots, so that new appointments up to existing appointments can be booked and this will be shown correctly. The end time calculation has also been resolved so that it shows the correct time in that scenario.

Front-end timeslot disabling has been removed as we are already performing the availability timeslot filtering on the backend for existing appointments.