### PR TITLE
Resolved Admin Support Request Message Fetching

### DIFF
--- a/src/app/bookings/[id]/balance/ReviewSection.tsx
+++ b/src/app/bookings/[id]/balance/ReviewSection.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from 'react';
 type ReviewSectionProps = {
   bookingId: string;
   professionalName: string;
+  isAdmin?: boolean;
 };
 
 type ReviewData = {
@@ -31,6 +32,7 @@ type ReviewStatus = {
 export function ReviewSection({
   bookingId,
   professionalName,
+  isAdmin = false,
 }: ReviewSectionProps) {
   const [reviewStatus, setReviewStatus] = useState<ReviewStatus | null>(null);
   const [loading, setLoading] = useState(true);
@@ -48,7 +50,7 @@ export function ReviewSection({
         const { getReviewStatus } = await import(
           '@/server/domains/reviews/actions'
         );
-        const result = await getReviewStatus(bookingId);
+        const result = await getReviewStatus(bookingId, isAdmin);
 
         if (result.success && result.reviewStatus) {
           setReviewStatus(result.reviewStatus);
@@ -65,7 +67,7 @@ export function ReviewSection({
     };
 
     fetchReviewStatus();
-  }, [bookingId]);
+  }, [bookingId, isAdmin]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -132,7 +134,7 @@ export function ReviewSection({
     return (
       <div className="space-y-4">
         <div className="flex items-center gap-2">
-          <span className="text-sm text-muted-foreground">Your rating:</span>
+          <span className="text-sm text-muted-foreground">Rating:</span>
           <div className="flex items-center">
             {[1, 2, 3, 4, 5].map((star) => (
               <Star
@@ -147,7 +149,7 @@ export function ReviewSection({
           </div>
         </div>
         <div>
-          <p className="text-sm text-muted-foreground mb-2">Your review:</p>
+          <p className="text-sm text-muted-foreground mb-2">Review:</p>
           <p className="text-sm bg-muted/50 p-3 rounded-lg border">
             {reviewStatus.review.message}
           </p>
@@ -160,7 +162,7 @@ export function ReviewSection({
     );
   }
 
-  // Show review form if can review
+  // Show review form if can review (only for clients)
   if (reviewStatus.canReview) {
     return (
       <div className="space-y-4">
@@ -223,6 +225,17 @@ export function ReviewSection({
     );
   }
 
-  // Cannot review (appointment not completed, etc.)
+  // Show "no review yet" message for professionals/admins when appointment is completed but no review exists
+  if (!reviewStatus.canReview && !reviewStatus.hasReview) {
+    return (
+      <div className="text-center py-6 space-y-3">
+        <Star className="h-8 w-8 text-muted-foreground mx-auto" />
+        <p className="text-muted-foreground text-sm">
+          No review has been submitted for this appointment yet.
+        </p>
+      </div>
+    );
+  }
+  
   return null;
 }

--- a/src/app/bookings/[id]/loading.tsx
+++ b/src/app/bookings/[id]/loading.tsx
@@ -1,0 +1,303 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { Typography } from '@/components/ui/typography';
+import {
+  ArrowLeftIcon,
+} from 'lucide-react';
+
+export default function BookingDetailLoading() {
+  return (
+    <div className="w-full">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-2 mb-6">
+          <div className="inline-flex items-center gap-2 text-muted-foreground">
+            <ArrowLeftIcon className="h-4 w-4" />
+            <Typography>Back to Appointments</Typography>
+          </div>
+        </div>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+            <div className="flex flex-col gap-2">
+              <Typography
+                variant="h1"
+                className="font-futura text-4xl md:text-5xl font-bold text-foreground"
+              >
+                Booking Details
+              </Typography>
+            </div>
+            <div className="flex items-center mt-2 sm:mt-0">
+              <div className="scale-110">
+                <Badge variant="outline" className="bg-primary/10 text-primary border-primary/20">
+                  <Skeleton className="h-4 w-16" />
+                </Badge>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        {/* Main Content */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Service Information */}
+          <Card className="shadow-sm">
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-6 w-32" />
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {/* Main Service */}
+              <div>
+                <Skeleton className="h-7 w-48 mb-2" />
+                <Skeleton className="h-4 w-full mb-4" />
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-4 w-4 rounded-full" />
+                    <Skeleton className="h-4 w-20" />
+                    <Skeleton className="h-4 w-16" />
+                  </div>
+                  <div className="flex items-center justify-end gap-2">
+                    <Skeleton className="h-4 w-4 rounded-full" />
+                    <Skeleton className="h-4 w-16" />
+                    <Skeleton className="h-4 w-16" />
+                  </div>
+                </div>
+              </div>
+
+              {/* Additional Services */}
+              <Separator />
+              <div>
+                <Skeleton className="h-6 w-40 mb-4" />
+                <div className="space-y-4">
+                  {[1, 2].map((i) => (
+                    <div key={i} className="flex justify-between items-start">
+                      <div className="flex-1">
+                        <Skeleton className="h-5 w-32 mb-1" />
+                        <Skeleton className="h-3 w-48 mb-1" />
+                        <div className="flex items-center gap-1">
+                          <Skeleton className="h-3 w-3 rounded-full" />
+                          <Skeleton className="h-3 w-16" />
+                        </div>
+                      </div>
+                      <Skeleton className="h-4 w-16" />
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Duration and Price Summary */}
+              <Separator />
+              <div className="space-y-3">
+                {/* Total Duration */}
+                <div className="flex justify-between items-center">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-4 w-4 rounded-full" />
+                    <Skeleton className="h-4 w-24" />
+                  </div>
+                  <Skeleton className="h-4 w-16" />
+                </div>
+
+                {/* Price Breakdown */}
+                <div className="space-y-2">
+                  {[1, 2, 3, 4].map((i) => (
+                    <div key={i} className="flex justify-between items-center">
+                      <Skeleton className="h-4 w-24" />
+                      <Skeleton className="h-4 w-16" />
+                    </div>
+                  ))}
+                  <Separator />
+                  <div className="flex justify-between items-center">
+                    <Skeleton className="h-5 w-16" />
+                    <Skeleton className="h-6 w-20" />
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Appointment Time & Location */}
+          <Card className="shadow-sm">
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-6 w-40" />
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <Skeleton className="h-5 w-20 mb-1" />
+                <Skeleton className="h-4 w-48 mb-1" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+              <div>
+                <Skeleton className="h-5 w-16 mb-1" />
+                <Skeleton className="h-4 w-full" />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Professional/Client Information */}
+          <Card className="shadow-sm">
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-6 w-40" />
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {/* Profile Header */}
+              <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-6">
+                <Skeleton className="h-20 w-20 sm:h-24 sm:w-24 rounded-full" />
+                <div className="flex-1 min-w-0">
+                  <Skeleton className="h-6 w-40 mb-1" />
+                  <div className="space-y-1">
+                    <Skeleton className="h-4 w-24" />
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-4 w-4 rounded-full" />
+                      <Skeleton className="h-4 w-32" />
+                    </div>
+                  </div>
+                </div>
+                <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+                  <Skeleton className="h-9 w-32" />
+                  <Skeleton className="h-9 w-28" />
+                </div>
+              </div>
+
+              {/* Description section */}
+              <Separator />
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-16" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-3/4" />
+              </div>
+
+              {/* Location Information */}
+              <Separator />
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-32 mb-1" />
+                
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-4 w-full" />
+                </div>
+
+                <div className="space-y-3">
+                  <Skeleton className="h-4 w-full" />
+
+                  {/* Map placeholder */}
+                  <Card className="mt-6">
+                    <CardHeader>
+                      <div className="flex items-center">
+                        <Skeleton className="h-5 w-32" />
+                      </div>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="relative w-full overflow-hidden rounded-lg">
+                        <Skeleton className="h-64 w-full" />
+                      </div>
+                      <div className="mt-4 flex justify-end">
+                        <Skeleton className="h-9 w-32" />
+                      </div>
+                    </CardContent>
+                  </Card>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          {/* Actions Card */}
+          <Card className="shadow-sm">
+            <CardHeader>
+              <Skeleton className="h-6 w-24" />
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </CardContent>
+          </Card>
+
+          {/* Payment Information */}
+          <Card className="shadow-sm">
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-6 w-32" />
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* Payment Amount and Status */}
+              <div className="space-y-2">
+                <div className="flex justify-between items-center">
+                  <Skeleton className="h-5 w-16" />
+                  <Skeleton className="h-6 w-20" />
+                </div>
+              </div>
+
+              <Separator />
+
+              {/* Payment Method */}
+              <div>
+                <div className="flex items-center gap-2 mb-1">
+                  <Skeleton className="h-5 w-28" />
+                  <Skeleton className="h-4 w-4 rounded-full" />
+                </div>
+                <Skeleton className="h-4 w-32" />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Review Section */}
+          <Card className="shadow-sm">
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-6 w-16" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-8 w-full" />
+                <div className="flex gap-1">
+                  {[1, 2, 3, 4, 5].map((i) => (
+                    <Skeleton key={i} className="h-6 w-6 rounded-full" />
+                  ))}
+                </div>
+                <Skeleton className="h-20 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Booking Details */}
+          <Card className="shadow-sm">
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-6 w-32" />
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <Skeleton className="h-5 w-24 mb-1" />
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-4 w-48" />
+                  <Skeleton className="h-6 w-6 rounded" />
+                </div>
+              </div>
+              <Separator />
+              <div>
+                <Skeleton className="h-5 w-20" />
+                <Skeleton className="h-4 w-40" />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pages/BookingDetailPage/BookingDetailPage.tsx
+++ b/src/components/pages/BookingDetailPage/BookingDetailPage.tsx
@@ -143,6 +143,7 @@ export async function BookingDetailPage({ id }: { id: string }) {
       isProfessional={isProfessional}
       isClient={isClient}
       userId={user.id}
+      isAdmin={isAdmin}
     />
   );
 }

--- a/src/components/pages/BookingDetailPage/BookingDetailPage.tsx
+++ b/src/components/pages/BookingDetailPage/BookingDetailPage.tsx
@@ -394,12 +394,12 @@ export async function getAppointmentById(
       },
     };
 
-    console.log('Fetched appointment:', {
-      id: transformedData.id,
-      status: transformedData.status,
-      computed_status: transformedData.computed_status,
-      raw: data,
-    });
+    // console.log('Fetched appointment:', {
+    //   id: transformedData.id,
+    //   status: transformedData.status,
+    //   computed_status: transformedData.computed_status,
+    //   raw: data,
+    // });
 
     return transformedData;
   } catch (error) {

--- a/src/components/pages/BookingDetailPage/BookingDetailPageClient.tsx
+++ b/src/components/pages/BookingDetailPage/BookingDetailPageClient.tsx
@@ -50,6 +50,7 @@ export type BookingDetailPageClientProps = {
   isClient: boolean;
   isProfessional: boolean;
   userId: string;
+  isAdmin?: boolean;
 };
 
 const phoneUtil = PhoneNumberUtil.getInstance();
@@ -101,6 +102,7 @@ export function BookingDetailPageClient({
   isClient,
   isProfessional,
   userId,
+  isAdmin = false,
 }: BookingDetailPageClientProps) {
   const [isUpdating, setIsUpdating] = useState(false);
   const [copySuccess, setCopySuccess] = useState(false);
@@ -501,7 +503,7 @@ export function BookingDetailPageClient({
       <div className="mb-8">
         <div className="flex items-center gap-2 mb-6">
           <Link
-            href="/dashboard/appointments"
+            href={isAdmin ? "/admin/appointments" : "/dashboard/appointments"}
             className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
           >
             <ArrowLeftIcon className="h-4 w-4" />
@@ -1197,7 +1199,7 @@ export function BookingDetailPageClient({
                 )}
 
                 {/* Support Request Button or Reference */}
-                {canRequestRefund() && (
+                {canRequestRefund() && !isAdmin && (
                   existingSupportRequest ? (
                     <Button
                       asChild

--- a/src/components/pages/BookingDetailPage/BookingDetailPageClient.tsx
+++ b/src/components/pages/BookingDetailPage/BookingDetailPageClient.tsx
@@ -112,7 +112,11 @@ export function BookingDetailPageClient({
   const [isRefundModalOpen, setIsRefundModalOpen] = useState(false);
   const [isCancellationModalOpen, setIsCancellationModalOpen] = useState(false);
   const [isNoShowModalOpen, setIsNoShowModalOpen] = useState(false);
-  const [existingSupportRequest, setExistingSupportRequest] = useState<{ id: string; status: string; category?: string } | null>(null);
+  const [existingSupportRequest, setExistingSupportRequest] = useState<{
+    id: string;
+    status: string;
+    category?: string;
+  } | null>(null);
   const [isLoadingSupportRequest, setIsLoadingSupportRequest] = useState(true);
 
   const router = useRouter();
@@ -235,7 +239,7 @@ export function BookingDetailPageClient({
       appointmentData.computed_status || appointmentData.status;
 
     // Professionals can update status for upcoming appointments
-    if (isProfessional) {
+    if (isProfessional || isAdmin) {
       return computedStatus === 'upcoming';
     }
 
@@ -301,7 +305,7 @@ export function BookingDetailPageClient({
       appointmentData.computed_status || appointmentData.status;
 
     // Only clients can request refunds
-    if (isProfessional) return false;
+    if (isProfessional || isAdmin) return false;
 
     // Only for completed appointments
     if (computedStatus !== 'completed') return false;
@@ -503,7 +507,7 @@ export function BookingDetailPageClient({
       <div className="mb-8">
         <div className="flex items-center gap-2 mb-6">
           <Link
-            href={isAdmin ? "/admin/appointments" : "/dashboard/appointments"}
+            href={isAdmin ? '/admin/appointments' : '/dashboard/appointments'}
             className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
           >
             <ArrowLeftIcon className="h-4 w-4" />
@@ -897,7 +901,10 @@ export function BookingDetailPageClient({
                 {/* Client Profile Header */}
                 <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-6">
                   <Avatar className="h-20 w-20 sm:h-24 sm:w-24 bg-white border-4 border-white shadow-md">
-                    <AvatarImage className="object-cover" src={getOtherPartyProfileData().avatar_url || ''} />
+                    <AvatarImage
+                      className="object-cover"
+                      src={getOtherPartyProfileData().avatar_url || ''}
+                    />
                     <AvatarFallback className="bg-primary/10 text-primary font-medium text-xl sm:text-2xl">
                       {getOtherPartyInitials()}
                     </AvatarFallback>
@@ -982,7 +989,10 @@ export function BookingDetailPageClient({
                 {/* Professional Profile Header */}
                 <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-6">
                   <Avatar className="h-20 w-20 sm:h-24 sm:w-24 bg-white border-4 border-white shadow-md">
-                    <AvatarImage className="object-cover" src={getOtherPartyProfileData().avatar_url || ''} />
+                    <AvatarImage
+                      className="object-cover"
+                      src={getOtherPartyProfileData().avatar_url || ''}
+                    />
                     <AvatarFallback className="bg-primary/10 text-primary font-medium text-xl sm:text-2xl">
                       {getOtherPartyInitials()}
                     </AvatarFallback>
@@ -1015,21 +1025,23 @@ export function BookingDetailPageClient({
                     </div>
                   </div>
                   <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
-                    <Button
-                      variant="outline"
-                      onClick={() =>
-                        handleMessageClick(
-                          appointment.bookings.professionals!.user_id,
-                        )
-                      }
-                      disabled={isMessageLoading}
-                      className="flex items-center gap-2 sm:min-w-[140px]"
-                    >
-                      <MessageCircleIcon className="h-4 w-4" />
-                      {isMessageLoading
-                        ? 'Starting...'
-                        : 'Message Professional'}
-                    </Button>
+                    {!isAdmin && (
+                      <Button
+                        variant="outline"
+                        onClick={() =>
+                          handleMessageClick(
+                            appointment.bookings.professionals!.user_id,
+                          )
+                        }
+                        disabled={isMessageLoading}
+                        className="flex items-center gap-2 sm:min-w-[140px]"
+                      >
+                        <MessageCircleIcon className="h-4 w-4" />
+                        {isMessageLoading
+                          ? 'Starting...'
+                          : 'Message Professional'}
+                      </Button>
+                    )}
                     <Button
                       variant="outline"
                       asChild
@@ -1147,14 +1159,14 @@ export function BookingDetailPageClient({
         {/* Sidebar */}
         <div className="space-y-6">
           {/* Status & Actions */}
-          {canUpdateStatus() && (
+          {canUpdateStatus() && !isAdmin && (
             <Card className="shadow-sm">
               <CardHeader>
                 <CardTitle className="text-xl">
-                  {appointmentData.computed_status === 'completed' || appointmentData.status === 'completed'
+                  {appointmentData.computed_status === 'completed' ||
+                  appointmentData.status === 'completed'
                     ? 'Questions about this appointment'
-                    : 'Actions'
-                  }
+                    : 'Actions'}
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-3">
@@ -1199,19 +1211,23 @@ export function BookingDetailPageClient({
                 )}
 
                 {/* Support Request Button or Reference */}
-                {canRequestRefund() && !isAdmin && (
-                  existingSupportRequest ? (
+                {canRequestRefund() &&
+                  !isAdmin &&
+                  (existingSupportRequest ? (
                     <Button
                       asChild
                       variant="outline"
                       className="w-full relative"
                     >
-                      <Link href={`/support-request/${existingSupportRequest.id}`}>
+                      <Link
+                        href={`/support-request/${existingSupportRequest.id}`}
+                      >
                         <div className="flex items-center justify-between w-full">
                           <div className="flex items-center">
                             <FileTextIcon className="h-4 w-4 mr-2" />
-                            {existingSupportRequest.category === 'refund_request' 
-                              ? 'View Refund Request' 
+                            {existingSupportRequest.category ===
+                            'refund_request'
+                              ? 'View Refund Request'
                               : 'View Support Request'}
                           </div>
                         </div>
@@ -1225,10 +1241,11 @@ export function BookingDetailPageClient({
                       disabled={isLoadingSupportRequest}
                     >
                       <RefreshCw className="h-4 w-4 mr-2" />
-                      {isLoadingSupportRequest ? 'Checking...' : 'Support Request'}
+                      {isLoadingSupportRequest
+                        ? 'Checking...'
+                        : 'Support Request'}
                     </Button>
-                  )
-                )}
+                  ))}
 
                 {/* No Show Button - Professional only, for completed appointments */}
                 {isProfessional &&
@@ -1318,24 +1335,24 @@ export function BookingDetailPageClient({
             </Card>
           )}
 
-          {/* Review Section - Show for completed appointments when user is client */}
-          {!isProfessional &&
-            appointmentData.computed_status === 'completed' && (
-              <Card className="shadow-sm">
-                <CardHeader>
-                  <CardTitle className="text-xl flex items-center gap-2">
-                    <Star className="h-5 w-5 text-muted-foreground" />
-                    Review
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ReviewSection
-                    bookingId={appointment.booking_id}
-                    professionalName={`${appointment.bookings.professionals?.users.first_name} ${appointment.bookings.professionals?.users.last_name}`}
-                  />
-                </CardContent>
-              </Card>
-            )}
+          {/* Review Section - Show for completed appointments when user is client or admin */}
+          {appointmentData.computed_status === 'completed' && (
+            <Card className="shadow-sm">
+              <CardHeader>
+                <CardTitle className="text-xl flex items-center gap-2">
+                  <Star className="h-5 w-5 text-muted-foreground" />
+                  Review
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ReviewSection
+                  bookingId={appointment.booking_id}
+                  professionalName={`${appointment.bookings.professionals?.users.first_name} ${appointment.bookings.professionals?.users.last_name}`}
+                  isAdmin={isAdmin}
+                />
+              </CardContent>
+            </Card>
+          )}
 
           {/* Booking Details */}
           <Card className="shadow-sm">

--- a/src/components/pages/SupportRequestDetailPage/SupportRequestChatWidget.tsx
+++ b/src/components/pages/SupportRequestDetailPage/SupportRequestChatWidget.tsx
@@ -36,6 +36,7 @@ type SupportRequestChatWidgetProps = {
     last_name: string;
     profile_photo_url?: string | undefined;
   };
+  usersMap?: Record<string, { id: string; first_name: string; last_name: string; profile_photo_url?: string }> | undefined;
   readOnly?: boolean;
   resolvedInfo?: {
     status: string;
@@ -43,6 +44,7 @@ type SupportRequestChatWidgetProps = {
     resolvedBy?: string | null;
     resolutionNotes?: string | null;
   } | undefined;
+  initialMessages?: ChatMessage[] | undefined;
 };
 
 // Image compression utility
@@ -123,14 +125,17 @@ const compressImage = async (file: File, quality = 0.8): Promise<File> => {
   }
 };
 
-export function SupportRequestChatWidget({
-  conversationId,
-  currentUserId,
-  otherUser,
-  readOnly = false,
-  resolvedInfo,
-}: SupportRequestChatWidgetProps) {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+export function SupportRequestChatWidget(props: SupportRequestChatWidgetProps) {
+  const {
+    conversationId,
+    currentUserId,
+    otherUser,
+    usersMap,
+    readOnly = false,
+    resolvedInfo,
+    initialMessages,
+  } = props;
+  const [messages, setMessages] = useState<ChatMessage[]>(initialMessages || []);
   const [conversation, setConversation] = useState<{
     id: string;
     other_user: {
@@ -543,13 +548,17 @@ export function SupportRequestChatWidget({
                   {message.sender_id !== currentUserId && (
                     <Avatar className="h-5 w-5 lg:h-6 lg:w-6 mb-1 hidden sm:block">
                       <AvatarImage
-                        src={conversation?.other_user.profile_photo_url}
+                        src={usersMap && usersMap[message.sender_id]?.profile_photo_url ? usersMap[message.sender_id]?.profile_photo_url : conversation?.other_user.profile_photo_url}
                       />
                       <AvatarFallback className="bg-muted text-foreground text-xs font-medium">
-                        {conversation ? getInitials(
-                          conversation.other_user.first_name,
-                          conversation.other_user.last_name,
-                        ) : ''}
+                        {usersMap?.[message.sender_id]?.first_name && usersMap?.[message.sender_id]?.last_name
+                          ? getInitials(
+                              usersMap[message.sender_id]?.first_name ?? '',
+                              usersMap[message.sender_id]?.last_name ?? ''
+                            )
+                          : conversation
+                          ? getInitials(conversation.other_user.first_name, conversation.other_user.last_name)
+                          : ''}
                       </AvatarFallback>
                     </Avatar>
                   )}

--- a/src/components/pages/SupportRequestDetailPage/SupportRequestDetailPage.tsx
+++ b/src/components/pages/SupportRequestDetailPage/SupportRequestDetailPage.tsx
@@ -43,11 +43,9 @@ export async function SupportRequestDetailPage({ id }: SupportRequestDetailPageP
       initialMessages = messagesResult.messages;
       usersMap = messagesResult.users;
     }
-  } else if (isProfessional) {
+  } else {
     result = await getSupportRequest(id);
     // Optionally: fetch messages for professionals here if needed
-  } else {
-    redirect('/');
   }
 
   if (!result.success || !result.supportRequest) {

--- a/src/components/pages/SupportRequestDetailPage/SupportRequestDetailPage.tsx
+++ b/src/components/pages/SupportRequestDetailPage/SupportRequestDetailPage.tsx
@@ -3,15 +3,14 @@
 import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import { SupportRequestDetailPageClient } from './SupportRequestDetailPageClient';
-import { getSupportRequest, getAdminSupportRequest } from '@/server/domains/support-requests/actions';
+import { getSupportRequest, getAdminSupportRequest, getAdminSupportRequestMessages } from '@/server/domains/support-requests/actions';
 
 export type SupportRequestDetailPageProps = {
   id: string;
 };
 
-export async function SupportRequestDetailPage({
-  id,
-}: SupportRequestDetailPageProps) {
+
+export async function SupportRequestDetailPage({ id }: SupportRequestDetailPageProps) {
   const supabase = await createClient();
 
   // Get the current user
@@ -34,10 +33,19 @@ export async function SupportRequestDetailPage({
   });
 
   let result;
+  let initialMessages = undefined;
+  let usersMap = undefined;
   if (isAdmin) {
     result = await getAdminSupportRequest(id);
+    // Fetch messages as admin
+    const messagesResult = await getAdminSupportRequestMessages(id);
+    if (messagesResult.success && 'messages' in messagesResult) {
+      initialMessages = messagesResult.messages;
+      usersMap = messagesResult.users;
+    }
   } else if (isProfessional) {
     result = await getSupportRequest(id);
+    // Optionally: fetch messages for professionals here if needed
   } else {
     redirect('/');
   }
@@ -52,6 +60,8 @@ export async function SupportRequestDetailPage({
       isProfessional={!!isProfessional}
       currentUserId={user.id}
       isAdmin={!!isAdmin}
+      initialMessages={initialMessages ?? []}
+      usersMap={usersMap ?? {}}
     />
   );
 }

--- a/src/server/domains/support-requests/actions.ts
+++ b/src/server/domains/support-requests/actions.ts
@@ -1,4 +1,5 @@
 import { createClient, createAdminClient } from '@/lib/supabase/server';
+export { getAdminSupportRequestMessages } from './admin-actions';
 /**
  * Get a single support request with all details (admin version)
  */

--- a/src/server/domains/support-requests/admin-actions.ts
+++ b/src/server/domains/support-requests/admin-actions.ts
@@ -1,0 +1,75 @@
+import { createAdminClient } from '@/lib/supabase/server';
+import { requireAdminUser } from '@/server/lib/auth';
+
+/**
+ * Fetch all messages for a support request (admin only).
+ */
+export async function getAdminSupportRequestMessages(supportRequestId: string) {
+  // 1. Check user is admin
+  const adminCheck = await requireAdminUser();
+  if (!adminCheck.success) {
+    return adminCheck;
+  }
+
+  // 2. Use admin client to fetch all messages for the support request
+  const adminSupabase = await createAdminClient();
+
+  // Fetch the conversation id for this support request
+  const { data: supportRequest, error: supportRequestError } = await adminSupabase
+    .from('support_requests')
+    .select('conversation_id')
+    .eq('id', supportRequestId)
+    .single();
+
+  if (supportRequestError || !supportRequest) {
+    return { success: false, error: 'Support request not found' };
+  }
+
+  // Fetch all messages for the conversation
+  const { data: messages, error: messagesError } = await adminSupabase
+    .from('messages')
+    .select('*')
+    .eq('conversation_id', supportRequest.conversation_id)
+    .order('created_at', { ascending: true });
+
+  if (messagesError) {
+    return { success: false, error: 'Failed to fetch messages' };
+  }
+
+  // Collect all unique sender IDs
+  const senderIds = Array.from(new Set((messages || []).map((msg) => msg.sender_id)));
+
+  const usersMap: Record<string, { id: string; first_name: string; last_name: string; profile_photo_url?: string } > = {};
+  if (senderIds.length > 0) {
+    // Fetch all users for these sender IDs, including profile photos
+    const { data: users, error: usersError } = await adminSupabase
+      .from('users')
+      .select('id, first_name, last_name, profile_photos(url)')
+      .in('id', senderIds);
+
+    if (usersError) {
+      return { success: false, error: 'Failed to fetch users' };
+    }
+
+    for (const user of users || []) {
+      let photoUrl: string | undefined = undefined;
+      if (user.profile_photos) {
+        if (Array.isArray(user.profile_photos)) {
+          if (user.profile_photos.length > 0) {
+            photoUrl = user.profile_photos[0].url;
+          }
+        } else if (user.profile_photos.url) {
+          photoUrl = user.profile_photos.url;
+        }
+      }
+      usersMap[user.id] = {
+        id: user.id,
+        first_name: user.first_name,
+        last_name: user.last_name,
+        ...(photoUrl ? { profile_photo_url: photoUrl } : {}),
+      };
+    }
+  }
+
+  return { success: true, messages, users: usersMap };
+}

--- a/src/utils/getDisplayName.ts
+++ b/src/utils/getDisplayName.ts
@@ -1,0 +1,18 @@
+/**
+ * Utility to get a display name for a user, with fallback logic.
+ * @param user User object with first_name, last_name, id
+ * @param fallback Fallback string if no name is available
+ */
+export function getDisplayName(
+  user: { first_name?: string | null; last_name?: string | null; id?: string } | null | undefined,
+  fallback: string = 'Unknown User'
+): string {
+  if (!user) return fallback;
+  const fn = user.first_name?.trim() || '';
+  const ln = user.last_name?.trim() || '';
+  if (fn && ln) return `${fn} ${ln}`;
+  if (fn) return fn;
+  if (ln) return ln;
+  if (user.id) return `${fallback} (${user.id})`;
+  return fallback;
+}

--- a/supabase/migrations/20250828110306_add_support_request_admin_professional_policies.sql
+++ b/supabase/migrations/20250828110306_add_support_request_admin_professional_policies.sql
@@ -1,0 +1,24 @@
+create policy "Admins can view all support requests"
+on "public"."support_requests"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM (users u
+     JOIN roles r ON ((u.role_id = r.id)))
+  WHERE ((u.id = auth.uid()) AND (r.name = 'admin'::text)))));
+
+
+create policy "Professionals can view support requests for their appointments"
+on "public"."support_requests"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM ((appointments a
+     JOIN bookings b ON ((a.booking_id = b.id)))
+     JOIN professional_profiles pp ON ((b.professional_profile_id = pp.id)))
+  WHERE ((a.id = support_requests.appointment_id) AND (pp.user_id = auth.uid())))));
+
+
+


### PR DESCRIPTION
Added function to fetch support request messages for an admin user viewing the support request details, and integrated this into the Support Request Detail Page and Chat Widget.

Updated the fetching of the message sender's avatar/initials to be correct for a viewing admin user.

Added a helper function for fetching user names to display in the People Involved section.

Removed 'Support Request' button from Booking Details page when an admin is viewing.

Changed the 'Back To Appointments' link to redirect to /admin/appointments when an admin user clicks it.